### PR TITLE
elevationをSliderで切り替えられるよう変更

### DIFF
--- a/MockApp/app/src/main/java/jp/kyam/mockapp/MainContract.kt
+++ b/MockApp/app/src/main/java/jp/kyam/mockapp/MainContract.kt
@@ -1,7 +1,10 @@
 package jp.kyam.mockapp
 
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
 data class MainState(
-    val param: Int = 0
+    val elevationValue: Dp = 0.dp
 )
 
 sealed class MainSideEffect {

--- a/MockApp/app/src/main/java/jp/kyam/mockapp/MainScreen.kt
+++ b/MockApp/app/src/main/java/jp/kyam/mockapp/MainScreen.kt
@@ -1,12 +1,25 @@
 package jp.kyam.mockapp
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import jp.kyam.mockapp.ui.theme.MockAppTheme
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
+import kotlin.math.roundToInt
 
 @Composable
 fun MainScreen(viewModel: MainViewModel) {
@@ -16,21 +29,104 @@ fun MainScreen(viewModel: MainViewModel) {
         //TODO SideEffectが必要な処理を追記
     }
 
-    Greeting("Android")
+    Contents(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+        name = "Android",
+        elevation = state.elevationValue,
+        onElevationChanged = { elevation -> viewModel.onElevationChanged(elevation) }
+    )
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
+fun Contents(
+    modifier: Modifier = Modifier,
+    name: String = "",
+    elevation: Dp = 0.dp,
+    onElevationChanged: (Dp) -> Unit = {}
+) {
+    Column(
         modifier = modifier
+    ) {
+        DummyButton(
+            name = name,
+            buttonElevation = ButtonDefaults.buttonElevation(
+                defaultElevation = elevation
+            )
+        )
+        ElevationSlider(
+            onValueChanged = onElevationChanged
+        )
+    }
+}
+
+@Composable
+fun DummyButton(
+    modifier: Modifier = Modifier,
+    name: String = "",
+    buttonElevation: ButtonElevation = ButtonDefaults.buttonElevation()
+) {
+    Button(
+        modifier = modifier,
+        onClick = { /*Do nothing*/ },
+        elevation = buttonElevation
+    ) {
+        Text(
+            text = "Hello $name!"
+        )
+    }
+}
+
+@Composable
+fun ElevationSlider(
+    modifier: Modifier = Modifier,
+    onValueChanged: (Dp) -> Unit = {}
+) {
+    var sliderPosition by remember { mutableFloatStateOf(0f) }
+    val elevationTokens = listOf(0.dp, 1.dp, 3.dp, 6.dp, 8.dp, 12.dp)
+    Column(
+        modifier = modifier
+    ) {
+        Slider(
+            value = sliderPosition,
+            onValueChange = { value ->
+                sliderPosition = value
+                val position = value.roundToInt()
+                onValueChanged(
+                    elevationTokens[position]
+                )
+            },
+            steps = 4,
+            valueRange = 0f..5f
+        )
+        Text(
+            text = "${elevationTokens[sliderPosition.roundToInt()]}"
+        )
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun MainScreenPreview(
+    name: String = "Android"
+) {
+    Contents(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+        name = name
     )
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun DummyButtonPreview() {
     MockAppTheme {
-        Greeting("Android")
+        DummyButton(name = "Android")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ElevationSliderPreview() {
+    MockAppTheme {
+        ElevationSlider()
     }
 }

--- a/MockApp/app/src/main/java/jp/kyam/mockapp/MainViewModel.kt
+++ b/MockApp/app/src/main/java/jp/kyam/mockapp/MainViewModel.kt
@@ -1,8 +1,11 @@
 package jp.kyam.mockapp
 
+import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
@@ -10,5 +13,9 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor() : ContainerHost<MainState, MainSideEffect>, ViewModel() {
     override val container = container<MainState, MainSideEffect>(MainState())
 
-    // TODO 以下にメソッドを追加
+    fun onElevationChanged(elevation: Dp) = intent {
+        reduce {
+            state.copy(elevationValue = elevation)
+        }
+    }
 }


### PR DESCRIPTION
## 内容

- StepSliderの作成
  - 参考：https://developer.android.com/jetpack/compose/components/slider#advanced-implementation
- Elevationの反映
- Previewの作成
  - 参考：https://developer.android.com/jetpack/compose/tooling/previews#preview-viewmodel
  - ViewModelを渡す方法もあったが公式に従いViewModelを渡さない方法を採用した
    - https://tech.opst.co.jp/2022/10/21/composable%E5%86%85%E3%81%A7viewmodel%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6preview%E3%81%99%E3%82%8B/
    - https://zenn.dev/satoryo56/articles/10e7697f0498cc

## 備考

Material3ではelevationを5段階にするのが推奨されていたため制限した

### 参考

- https://m3.material.io/styles/elevation/applying-elevation